### PR TITLE
Render graph: Fix topological sort in ::Compile()

### DIFF
--- a/MiniEngine/Core/RenderGraph/Base/BaseGraph.h
+++ b/MiniEngine/Core/RenderGraph/Base/BaseGraph.h
@@ -37,55 +37,6 @@ namespace RenderGraph
         std::vector<GraphEdge<EdgeType>> m_edges;
         std::wstring m_title;
 
-    protected:
-        std::vector<std::size_t> TopologicalSort() const {
-            std::vector<std::size_t> result;
-            result.reserve(m_nodes.size());
-
-            std::vector<std::size_t> inDegree(m_nodes.size(), 0);
-            for (const auto& node : m_nodes) {
-                inDegree[&node - m_nodes[0]] = node.inputEdges.size();
-            }
-
-            std::queue<std::size_t> zeroInDegreeQueue;
-            for (std::size_t i = 0; i < inDegree.size(); ++i)
-            {
-                if (inDegree[i] == 0)
-                {
-                    zeroInDegreeQueue.push(i);
-                }
-            }
-
-            // Process nodes
-            std::size_t visitedCount = 0;
-            while (!zeroInDegreeQueue.empty())
-            {
-                std::size_t currentNode = zeroInDegreeQueue.front();
-                zeroInDegreeQueue.pop();
-                result.push_back(currentNode);
-                ++visitedCount;
-
-                // Reduce in-degree of all adjacent nodes
-                for (const auto& edgeId : m_nodes[currentNode].outputEdges)
-                {
-                    const auto& edge = m_edges[edgeId];
-                    std::size_t adjacentNode = edge.toNode;
-                    if (--inDegree[adjacentNode] == 0)
-                    {
-                        zeroInDegreeQueue.push(adjacentNode);
-                    }
-                }
-            }
-
-            // Check for cycles
-            if (visitedCount != m_nodes.size())
-            {
-                throw std::runtime_error("Graph contains at least one cycle");
-            }
-
-            return result;
-        }
-
     public:
         BaseGraph() = default;
         virtual ~BaseGraph() = default;

--- a/MiniEngine/Core/RenderGraph/RenderGraph.cpp
+++ b/MiniEngine/Core/RenderGraph/RenderGraph.cpp
@@ -36,11 +36,7 @@ namespace RenderGraph
 
         // Calculate in-degree for each node
         for (std::size_t i = 0; i < GetNodeCount(); ++i) {
-            const auto& node = GetNode(i);
-            for (std::size_t edgeId : node.inputEdges) {
-                const auto& edge = GetEdge(edgeId);
-                inDegree[edge.fromNode]++;
-            }
+            inDegree[i] = GetNode(i).inputEdges.size();
         }
 
         // Find initial ready nodes (in-degree = 0)

--- a/MiniEngine/Model/SponzaRenderer.cpp
+++ b/MiniEngine/Model/SponzaRenderer.cpp
@@ -80,9 +80,9 @@ namespace Sponza
 
 void Sponza::Startup( Camera& Camera, bool useRenderGraph)
 {
-    //if (useRenderGraph) {
-    //    g_renderGraph = std::make_unique<RenderGraph::RenderGraph>();
-    //}
+    if (useRenderGraph) {
+        g_renderGraph = std::make_unique<RenderGraph::RenderGraph>();
+    }
 
     DXGI_FORMAT ColorFormat = g_SceneColorBuffer.GetFormat();
     DXGI_FORMAT NormalFormat = g_SceneNormalBuffer.GetFormat();
@@ -660,13 +660,13 @@ void Sponza::RenderSceneRenderGraph(GraphicsContext& gfxContext, const Math::Cam
         );
     }
 
-    //g_renderGraph->Compile();
-    //gfxContext.SetRootSignature(Renderer::m_RootSig);
-    //gfxContext.SetDescriptorHeap(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, Renderer::s_TextureHeap.GetHeapPointer());
-    //gfxContext.SetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
-    //gfxContext.SetIndexBuffer(m_Model.GetIndexBuffer());
-    //gfxContext.SetVertexBuffer(0, m_Model.GetVertexBuffer());
-    //g_renderGraph->Execute(gfxContext.GetCommandList());
+    g_renderGraph->Compile();
+    gfxContext.SetRootSignature(Renderer::m_RootSig);
+    gfxContext.SetDescriptorHeap(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, Renderer::s_TextureHeap.GetHeapPointer());
+    gfxContext.SetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+    gfxContext.SetIndexBuffer(m_Model.GetIndexBuffer());
+    gfxContext.SetVertexBuffer(0, m_Model.GetVertexBuffer());
+    g_renderGraph->Execute(gfxContext.GetCommandList());
 
 }
 


### PR DESCRIPTION
Fix topological sort by changing the logic of calculating in-degrees of nodes. Also removes `BaseGraph::TopologicalSort()`.