### PR TITLE
Render graph: Full pipeline in alternative (storaged) implementation

### DIFF
--- a/MiniEngine/Core/RenderGraph/Base/BaseGraph.h
+++ b/MiniEngine/Core/RenderGraph/Base/BaseGraph.h
@@ -4,6 +4,8 @@
 #include <memory>
 #include <string>
 #include <queue>
+#include <unordered_map>
+#include <algorithm>
 #include <assert.h>
 
 
@@ -104,4 +106,118 @@ namespace RenderGraph
 
     };
 
+    struct GraphNodeIndexed final
+    {
+        std::wstring dataIndex;
+        std::vector<std::size_t> inputEdges;
+        std::vector<std::size_t> outputEdges;
+    };
+
+    struct GraphEdgeIndexed
+    {
+        std::wstring dataIndex;
+        std::size_t fromNode;
+        std::size_t toNode;
+    };
+
+    template <typename NodeType, typename EdgeType>
+    class BaseGraphStoraged
+    {
+        using NodeTypePtr = std::unique_ptr<NodeType>;
+        using EdgeTypePtr = std::unique_ptr<EdgeType>;
+
+    protected:
+        std::vector<std::size_t> m_executionOrder;
+        std::vector<GraphNodeIndexed> m_nodes;
+        std::vector<GraphEdgeIndexed> m_edges;
+        std::unordered_map<std::wstring, NodeTypePtr> m_nodeStorage;
+        std::unordered_map<std::wstring, EdgeTypePtr> m_edgeStorage;
+
+    public:
+        BaseGraphStoraged() = default;
+        virtual ~BaseGraphStoraged() = default;
+
+        void StoreNode(NodeTypePtr nodeData, const std::wstring& nodeId) {
+            m_nodeStorage.emplace(nodeId, std::move(nodeData));
+        }
+
+        std::size_t AddNode(const std::wstring& nodeId) {
+            assert(m_nodeStorage.find(nodeId) != m_nodeStorage.end());
+            std::size_t id = m_nodes.size();
+            m_nodes.push_back({ std::move(nodeId), {}, {} });
+            return id;
+        }
+
+        void StoreEdge(EdgeTypePtr edgeData, const std::wstring& nodeId) {
+            m_edgeStorage.emplace(nodeId, std::move(edgeData));
+        }
+
+        std::size_t AddEdge(std::size_t fromNode, std::size_t toNode, const std::wstring& nodeId) {
+            auto nodesSize = m_nodes.size();
+            assert(fromNode < m_nodes.size() && toNode < m_nodes.size());
+
+            assert(m_edgeStorage.find(nodeId) != m_edgeStorage.end());
+
+            std::size_t id = m_edges.size();
+            m_edges.push_back({ std::move(nodeId), fromNode, toNode });
+
+            m_nodes[fromNode].outputEdges.push_back(id);
+            m_nodes[toNode].inputEdges.push_back(id);
+
+            return id;
+        }
+
+        void Clear() {
+            for (auto& node : m_nodes) {
+                node.inputEdges.clear();
+                node.outputEdges.clear();
+            }
+            m_nodes.clear();
+            m_edges.clear();
+        }
+
+        const NodeTypePtr& GetNodeData(std::wstring id) const {
+            assert(m_nodeStorage.find(id) != m_nodeStorage.end());
+            return m_nodeStorage.at(id);
+        }
+
+        NodeTypePtr& GetNodeData(std::wstring id) {
+            assert(m_nodeStorage.find(id) != m_nodeStorage.end());
+            return m_nodeStorage.at(id);
+        }
+
+        const GraphNodeIndexed& GetNode(std::size_t id) const {
+            assert(id < m_nodes.size());
+            return m_nodes[id];
+        }
+
+        GraphNodeIndexed& GetNode(std::size_t id) {
+            assert(id < m_nodes.size());
+            return m_nodes[id];
+        }
+
+        const EdgeTypePtr& GetEdgeData(std::wstring id) const {
+            assert(m_edgeStorage.find(id) != m_edgeStorage.end());
+            return m_edgeStorage[id];
+        }
+
+        EdgeTypePtr& GetEdgeData(std::wstring id) {
+            assert(m_edgeStorage.find(id) != m_edgeStorage.end());
+            return m_edgeStorage[id];
+        }
+
+        const GraphEdgeIndexed& GetEdge(std::size_t id) const {
+            assert(id < m_edges.size());
+            return m_edges[id];
+        }
+
+        GraphEdgeIndexed& GetEdge(std::size_t id) {
+            assert(id < m_edges.size());
+            return m_edges[id];
+        }
+
+        std::size_t GetNodeCount() const { return m_nodes.size(); }
+        std::size_t GetEdgeCount() const { return m_edges.size(); }
+
+    };
 }

--- a/MiniEngine/Core/RenderGraph/Passes/LambdaRenderPass.cpp
+++ b/MiniEngine/Core/RenderGraph/Passes/LambdaRenderPass.cpp
@@ -15,8 +15,23 @@ namespace RenderGraph
 
     }
 
-    void LambdaRenderPass::Execute(ID3D12GraphicsCommandList* cmdList)
+    void LambdaRenderPass::Execute(CommandContext& ctx)
     {
-        m_executeFunction(cmdList);
+        m_executeFunction(ctx.GetCommandList());
+    }
+
+    LambdaContextRenderPass::LambdaContextRenderPass(const std::wstring& name, executeContextFunction execFunc)
+        : RenderPass(name), m_executeFunction(std::move(execFunc))
+    {
+    }
+
+    void LambdaContextRenderPass::Setup(RenderGraph& renderGraph)
+    {
+
+    }
+
+    void LambdaContextRenderPass::Execute(CommandContext& ctx)
+    {
+        m_executeFunction(ctx);
     }
 }

--- a/MiniEngine/Core/RenderGraph/Passes/LambdaRenderPass.h
+++ b/MiniEngine/Core/RenderGraph/Passes/LambdaRenderPass.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "CommandContext.h"
 #include "RenderGraph/RenderPass.h"
 
 
@@ -13,11 +14,27 @@ namespace RenderGraph
         ~LambdaRenderPass() = default;
 
         void Setup(RenderGraph& renderGraph) override;
-        void Execute(ID3D12GraphicsCommandList* cmdList) override;
+        void Execute(CommandContext& ctx) override;
 
 
     private:
         executeFunction m_executeFunction;
+
+    };
+
+    class LambdaContextRenderPass : public RenderPass
+    {
+    public:
+        using executeContextFunction = std::function<void(CommandContext&)>;
+        LambdaContextRenderPass(const std::wstring& name, executeContextFunction execFunc);
+        ~LambdaContextRenderPass() = default;
+
+        void Setup(RenderGraph& renderGraph) override;
+        void Execute(CommandContext& ctx) override;
+
+
+    private:
+        executeContextFunction m_executeFunction;
 
     };
 }

--- a/MiniEngine/Core/RenderGraph/RenderGraph.cpp
+++ b/MiniEngine/Core/RenderGraph/RenderGraph.cpp
@@ -74,11 +74,11 @@ namespace RenderGraph
         }
     }
 
-    void RenderGraph::Execute(ID3D12GraphicsCommandList* commandList)
+    void RenderGraph::Execute(CommandContext& ctx)
     {
         for (std::size_t nodeId : m_executionOrder) {
             auto& node = GetNode(nodeId);
-            node.data->Execute(commandList);
+            node.data->Execute(ctx);
         }
     }
 
@@ -155,6 +155,202 @@ namespace RenderGraph
     }
 
     D3D12_RESOURCE_STATES RenderGraph::GetCurrentState(const std::shared_ptr<RenderGraphResource>& resource) const
+    {
+        return resource->GetDescription().initialState;
+    }
+
+    RenderGraphStoraged::RenderGraphStoraged()
+        : BaseGraphStoraged<RenderPass, RenderGraphEdgeResourceData>()
+    {
+    }
+
+    std::shared_ptr<RenderGraphResource> RenderGraphStoraged::CreateResource(const std::wstring& name, const RenderGraphResourceDesc& desc)
+    {
+        auto resource = std::make_shared<RenderGraphResource>(name, desc);
+        //m_resources[name] = resource;
+        m_resources.insert({ name, resource });
+        return resource;
+    }
+
+    std::shared_ptr<RenderGraphResource> RenderGraphStoraged::GetResource(const std::wstring& name) const
+    {
+        auto it = m_resources.find(name);
+        return it != m_resources.end() ? it->second : nullptr;
+    }
+
+    void RenderGraphStoraged::Compile()
+    {
+
+        /////////////////////
+        // Topological sort
+        /////////////////////
+
+        m_executionOrder.clear();
+        std::vector<std::size_t> inDegree(GetNodeCount(), 0);
+        std::vector<std::size_t> readyNodes;
+
+        // Calculate in-degree for each node
+        for (std::size_t i = 0; i < GetNodeCount(); ++i) {
+            inDegree[i] = GetNode(i).inputEdges.size();
+        }
+
+        // Find initial ready nodes (in-degree = 0)
+        for (std::size_t i = 0; i < GetNodeCount(); ++i) {
+            if (inDegree[i] == 0) {
+                readyNodes.push_back(i);
+            }
+        }
+
+        /////////////////////
+        // Process
+        /////////////////////
+
+        while (!readyNodes.empty()) {
+            std::size_t nodeId = readyNodes.back();
+            readyNodes.pop_back();
+            m_executionOrder.push_back(nodeId);
+
+            // Update in-degree of neighbors
+            const auto& node = GetNode(nodeId);
+            for (std::size_t edgeId : node.outputEdges) {
+                const auto& edge = GetEdge(edgeId);
+                if (--inDegree[edge.toNode] == 0) {
+                    readyNodes.push_back(edge.toNode);
+                }
+            }
+        }
+
+        // Check for cycles
+        if (m_executionOrder.size() != GetNodeCount()) {
+            throw std::runtime_error("Render graph contains cycles");
+        }
+    }
+
+    void RenderGraphStoraged::Execute(CommandContext& ctx)
+    {
+        for (std::size_t nodeId : m_executionOrder) {
+            auto& node = GetNode(nodeId);
+            m_nodeStorage.at(node.dataIndex)->Execute(ctx);
+        }
+    }
+
+    void RenderGraphStoraged::Clear()
+    {
+        BaseGraphStoraged<RenderPass, RenderGraphEdgeResourceData>::Clear();
+        // m_resources.clear();
+    }
+
+    nlohmann::json RenderGraphStoraged::Serialize() const
+    {
+        nlohmann::json json;
+
+        // Serialize resources
+
+        nlohmann::json resourcesJson;
+        for (const auto& resource : m_resources) {
+            const auto& desc = resource.second->GetDescription();
+            const auto& name = resource.first;
+
+            nlohmann::json resourceJson;
+            resourceJson["type"]            = static_cast<int>(desc.type);
+            resourceJson["format"]          = static_cast<int>(desc.format);
+            resourceJson["height"]          = desc.height;
+            resourceJson["width"]           = desc.width;
+            resourceJson["depth"]           = desc.depth;
+            resourceJson["mip_levels"]      = desc.mipLevels;
+            resourceJson["array_size"]      = desc.arraySize;
+            resourceJson["sample_count"]    = desc.sampleCount;
+            resourceJson["flags"]           = static_cast<int>(desc.flags);
+            resourceJson["initial_state"]   = static_cast<int>(desc.initialState);
+
+            resourcesJson[StringUtils::WideToNarrow(name)] = resourceJson;
+        }
+        json["resources"] = resourcesJson;
+
+        // Serialize nodes
+        nlohmann::json nodesJson;
+        for (std::size_t i = 0; i < this->GetNodeCount(); ++i) {
+            const auto& node = GetNode(i);
+            nlohmann::json nodeJson;
+
+            nodeJson["name"] = StringUtils::WideToNarrow(node.dataIndex);
+            nodeJson["type"] = typeid(*(m_nodeStorage.at(node.dataIndex))).name();
+
+            // Serialize output edges
+            nlohmann::json edgesJson;
+            for (std::size_t edgeId : node.outputEdges) {
+                const auto& edge = GetEdge(edgeId);
+                nlohmann::json edgeJson;
+
+                edgeJson["name"] = StringUtils::WideToNarrow(edge.dataIndex);
+                edgeJson["to_node"] = edge.toNode;
+                edgeJson["data"]    = m_edgeStorage.at(edge.dataIndex)->Serialize();
+                edgesJson.push_back(edgeJson);
+            }
+            nodeJson["output_edges"] = edgesJson;
+            nodesJson.push_back(nodeJson);
+        }
+        json["nodes"] = nodesJson;
+
+        // Serialize execution order
+        if (!m_executionOrder.empty()) {
+            json["execution_order"] = m_executionOrder;
+        }
+
+        return json;
+    }
+
+    void RenderGraphStoraged::ExportToJSON() const
+    {
+        std::ofstream out("./render_graph.json");
+        out << this->Serialize().dump();
+        out.close();
+    }
+
+    RenderGraphStoraged* RenderGraphStoraged::Deserialize(const nlohmann::json& from)
+    {
+        RenderGraphStoraged* result = new RenderGraphStoraged();
+
+        for (const auto& entry : from["resources"].items()) {
+            RenderGraphResourceDesc desc = {
+                static_cast<RenderGraphResourceType>(entry.value()["type"]),
+                static_cast<DXGI_FORMAT>(entry.value()["format"]),
+                static_cast<std::uint32_t>(entry.value()["height"]),
+                static_cast<std::uint32_t>(entry.value()["width"]),
+                static_cast<std::uint16_t>(entry.value()["depth"]),
+                static_cast<std::uint16_t>(entry.value()["mip_levels"]),
+                static_cast<std::uint16_t>(entry.value()["array_size"]),
+                static_cast<std::uint32_t>(entry.value()["sample_count"]),
+                static_cast<D3D12_RESOURCE_FLAGS>(entry.value()["flags"]),
+                static_cast<D3D12_RESOURCE_STATES>(entry.value()["initial_state"]),
+            };
+
+            result->CreateResource(StringUtils::NarrowToWide(entry.key()), desc);
+        }
+
+        // for (const auto& [key, value] : from["nodes"].items()) {
+            //
+        // }
+
+        if (from.contains("execution_order")) {
+            result->m_executionOrder.clear();
+            result->m_executionOrder.reserve(from["execution_order"].size());
+            for (const auto& entry : from["execution_order"].items()) {
+                result->m_executionOrder.push_back(entry.value());
+            }
+        }
+
+        return result;
+    }
+
+    RenderGraphStoraged* RenderGraphStoraged::ImportFromJSON()
+    {
+        std::ifstream in("render_graph.json");
+        nlohmann::json serialized = nlohmann::json::parse(in);
+        return RenderGraphStoraged::Deserialize(serialized);
+    }
+
+    D3D12_RESOURCE_STATES RenderGraphStoraged::GetCurrentState(const std::shared_ptr<RenderGraphResource>& resource) const
     {
         return resource->GetDescription().initialState;
     }

--- a/MiniEngine/Core/RenderGraph/RenderGraph.h
+++ b/MiniEngine/Core/RenderGraph/RenderGraph.h
@@ -21,11 +21,36 @@ namespace RenderGraph
         std::shared_ptr<RenderGraphResource> GetResource(const std::wstring& name) const;
 
         void Compile();
-        void Execute(ID3D12GraphicsCommandList* commandList);
+        void Execute(CommandContext& ctx);
         void Clear();
 
         nlohmann::json Serialize() const;
         void ExportToJSON() const;
+
+        D3D12_RESOURCE_STATES GetCurrentState(const std::shared_ptr<RenderGraphResource>& resource) const;
+
+    };
+
+    class RenderGraphStoraged final : public BaseGraphStoraged<RenderPass, RenderGraphEdgeResourceData>
+    {
+    private:
+        std::unordered_map<std::wstring, std::shared_ptr<RenderGraphResource>> m_resources;
+
+    public:
+        RenderGraphStoraged();
+
+        std::shared_ptr<RenderGraphResource> CreateResource(const std::wstring& name, const RenderGraphResourceDesc& desc);
+        std::shared_ptr<RenderGraphResource> GetResource(const std::wstring& name) const;
+
+        void Compile();
+        void Execute(CommandContext& ctx);
+        void Clear();
+
+        nlohmann::json Serialize() const;
+        void ExportToJSON() const;
+
+        static RenderGraphStoraged* Deserialize(const nlohmann::json& from);
+        static RenderGraphStoraged* ImportFromJSON();
 
         D3D12_RESOURCE_STATES GetCurrentState(const std::shared_ptr<RenderGraphResource>& resource) const;
 

--- a/MiniEngine/Core/RenderGraph/RenderPass.h
+++ b/MiniEngine/Core/RenderGraph/RenderPass.h
@@ -16,7 +16,7 @@ namespace RenderGraph
         virtual ~RenderPass() = default;
 
         virtual void Setup(RenderGraph& renderGraph) = 0;
-        virtual void Execute(ID3D12GraphicsCommandList* cmdList) = 0;
+        virtual void Execute(CommandContext& ctx) = 0;
 
         const std::wstring& GetName() const;
 

--- a/MiniEngine/Core/Util/StringUtils.cpp
+++ b/MiniEngine/Core/Util/StringUtils.cpp
@@ -16,4 +16,14 @@ namespace StringUtils
         > utf16conv;
         return utf16conv.to_bytes(aWide);
     }
+    
+    std::wstring NarrowToWide(const std::string& aNarrow)
+    {
+        if (aNarrow.empty()) return L"";
+        std::wstring_convert<
+            std::codecvt_utf8_utf16<std::wstring::value_type>,
+            std::wstring::value_type
+        > utf16conv;
+        return utf16conv.from_bytes(aNarrow);
+    }
 }

--- a/MiniEngine/Model/SponzaRenderer.cpp
+++ b/MiniEngine/Model/SponzaRenderer.cpp
@@ -18,12 +18,17 @@
 #include "Camera.h"
 #include "CommandContext.h"
 #include "TemporalEffects.h"
+#include "MotionBlur.h"
+#include "DepthOfField.h"
+#include "PostEffects.h"
 #include "SSAO.h"
 #include "SystemTime.h"
 #include "ShadowCamera.h"
 #include "ParticleEffects.h"
+#include "ParticleEffectManager.h"
 #include "SponzaRenderer.h"
 #include "Renderer.h"
+#include "Display.h"
 
 // From Model
 #include "ModelH3D.h"
@@ -65,9 +70,14 @@ namespace Sponza
     // after initialization. May be i don't know something. By the way, it is
     // working with raw pointer and i'm ok with this.
     RenderGraph::RenderGraph* g_renderGraph;
+    RenderGraph::RenderGraphStoraged* g_renderGraphStoraged;
 
     Vector3 m_SunDirection;
     ShadowCamera m_SunShadow;
+    Math::Camera m_Camera;
+    D3D12_VIEWPORT m_Viewport;
+    D3D12_RECT m_Scissor;
+    std::uint32_t m_FrameIndex;
 
     ExpVar m_AmbientIntensity("Sponza/Lighting/Ambient Intensity", 0.1f, -16.0f, 16.0f, 0.1f);
     ExpVar m_SunLightIntensity("Sponza/Lighting/Sun Light Intensity", 4.0f, 0.0f, 16.0f, 0.1f);
@@ -159,6 +169,8 @@ void Sponza::Startup( Camera& Camera, bool useRenderGraph)
     }
 
     ParticleEffects::InitFromJSON(L"Sponza/particles.json");
+
+    Sponza::RenderGraphStartup();
 
     float modelRadius = Length(m_Model.GetBoundingBox().GetDimensions()) * 0.5f;
     const Vector3 eye = m_Model.GetBoundingBox().GetCenter() + Vector3(modelRadius * 0.5f, 0.0f, 0.0f);
@@ -662,11 +674,436 @@ void Sponza::RenderSceneRenderGraph(GraphicsContext& gfxContext, const Math::Cam
     gfxContext.SetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
     gfxContext.SetIndexBuffer(m_Model.GetIndexBuffer());
     gfxContext.SetVertexBuffer(0, m_Model.GetVertexBuffer());
-    g_renderGraph->Execute(gfxContext.GetCommandList());
+    g_renderGraph->Execute(gfxContext);
+}
 
+void Sponza::RenderSceneRenderGraphStoraged(GraphicsContext& gfxContext, const Math::Camera& camera, const D3D12_VIEWPORT& viewport, const D3D12_RECT& scissor, bool skipDiffusePass, bool skipShadowMap)
+{
+    m_Camera = camera;
+    m_Viewport = viewport;
+    m_Scissor = scissor;
+    Renderer::UpdateGlobalDescriptors();
+    m_FrameIndex = TemporalEffects::GetFrameIndexMod2();
+
+    // Calculate sun direction
+    float costheta = cosf(m_SunOrientation);
+    float sintheta = sinf(m_SunOrientation);
+    float cosphi = cosf(m_SunInclination * 3.14159f * 0.5f);
+    float sinphi = sinf(m_SunInclination * 3.14159f * 0.5f);
+    m_SunDirection = Normalize(Vector3(costheta * cosphi, sinphi, sintheta * cosphi));
+
+    g_renderGraphStoraged->Clear();
+
+    std::size_t particleUpdatePassId = g_renderGraphStoraged->AddNode(L"ParticleUpdatePass");
+    std::size_t lightShadowPassId = g_renderGraphStoraged->AddNode(L"LightShadowPass");
+    std::size_t shadowPassId = g_renderGraphStoraged->AddNode(L"ShadowPass");
+    std::size_t depthPrePassId = g_renderGraphStoraged->AddNode(L"DepthPrePass");
+    std::size_t mainRenderPassId = g_renderGraphStoraged->AddNode(L"MainRenderPass");
+    std::size_t velocityPassId = g_renderGraphStoraged->AddNode(L"VelocityGatherPass");
+    std::size_t taaResolvePassId = g_renderGraphStoraged->AddNode(L"TAAResolvePass");
+    std::size_t particleRenderPassId = g_renderGraphStoraged->AddNode(L"ParticleRenderPass");
+
+    // -------- Add edge dependencies
+
+    // TODO: some of the nodes just use dummy resources for order control
+    // figure out actual dependencies later. Especially for particles
+
+    g_renderGraphStoraged->AddEdge(
+        particleUpdatePassId,
+        particleRenderPassId,
+        L"Dummy"
+    );
+
+    g_renderGraphStoraged->AddEdge(
+        lightShadowPassId,
+        depthPrePassId,
+        L"Dummy"
+    );
+
+    if (!skipShadowMap) {
+        g_renderGraphStoraged->AddEdge(
+            lightShadowPassId,
+            shadowPassId,
+            L"Dummy"
+        );
+
+        g_renderGraphStoraged->AddEdge(
+            shadowPassId,
+            mainRenderPassId,
+            L"Dummy"
+        );
+
+        g_renderGraphStoraged->AddEdge(
+            depthPrePassId,
+            shadowPassId,
+            L"ShadowPixel"
+        );
+    }
+
+    g_renderGraphStoraged->AddEdge(
+        depthPrePassId,
+        mainRenderPassId,
+        L"DepthRead"
+    );
+
+    if (!SSAO::DebugDraw) {
+        std::size_t ssaoPassId = g_renderGraphStoraged->AddNode(L"SSAOPass");
+
+        g_renderGraphStoraged->AddEdge(
+            depthPrePassId,
+            ssaoPassId,
+            L"DepthNonPixel"
+        );
+
+        g_renderGraphStoraged->AddEdge(
+            ssaoPassId,
+            mainRenderPassId,
+            L"Dummy"
+        );
+    }
+
+    if (!skipDiffusePass) {
+        std::size_t lightGridPassId = g_renderGraphStoraged->AddNode(L"LightGridPass");
+
+        g_renderGraphStoraged->AddEdge(
+            depthPrePassId,
+            lightGridPassId,
+            L"DepthNonPixel"
+        );
+
+        g_renderGraphStoraged->AddEdge(
+            lightGridPassId,
+            mainRenderPassId,
+            L"Dummy"
+        );
+    }
+
+    g_renderGraphStoraged->AddEdge(
+        mainRenderPassId,
+        velocityPassId,
+        L"ColorNonPixel"
+    );
+
+    g_renderGraphStoraged->AddEdge(
+        velocityPassId,
+        taaResolvePassId,
+        L"VelocityNonPixel"
+    );
+
+    g_renderGraphStoraged->AddEdge(
+        taaResolvePassId,
+        particleRenderPassId,
+        L"ColorRenderTarget"
+    );
+
+    // DoF and motion blur implementations are currently incompatible
+    // DoF has priority when enabled
+    if (DepthOfField::Enable) {
+        std::size_t depthOfFieldPassId = g_renderGraphStoraged->AddNode(L"DepthOfFieldPass");
+        g_renderGraphStoraged->AddEdge(
+            particleRenderPassId,
+            depthOfFieldPassId,
+            L"ColorNonPixel"
+        );
+    } else { // Enable Motion Blur instead
+        std::size_t motionBlurPassId = g_renderGraphStoraged->AddNode(L"MotionBlurPass");
+        g_renderGraphStoraged->AddEdge(
+            particleRenderPassId,
+            motionBlurPassId,
+            L"ColorNonPixel"
+        );
+        g_renderGraphStoraged->AddEdge(
+            velocityPassId,
+            motionBlurPassId,
+            L"VelocityNonPixel"
+        );
+    }
+
+    g_renderGraphStoraged->Compile();
+    g_renderGraphStoraged->Execute(gfxContext);
 }
 
 void Sponza::RenderGraphStartup()
 {
+    g_renderGraph = new RenderGraph::RenderGraph();
+    g_renderGraphStoraged = new RenderGraph::RenderGraphStoraged();
+    // Create resources once
+    // TODO: find a way to represent particle resources
+    auto backBuffer = g_renderGraphStoraged->CreateResource(L"BackBuffer", {
+        RenderGraph::RenderGraphResourceType::RTV,
+        g_SceneColorBuffer.GetFormat(),
+        g_SceneColorBuffer.GetWidth(),
+        g_SceneColorBuffer.GetHeight()
+    });
+    backBuffer->SetResource(g_SceneColorBuffer.GetResource());
 
+    auto depthBuffer = g_renderGraphStoraged->CreateResource(L"DepthBuffer", {
+        RenderGraph::RenderGraphResourceType::DSV,
+        g_SceneDepthBuffer.GetFormat(),
+        g_SceneDepthBuffer.GetWidth(),
+        g_SceneDepthBuffer.GetHeight()
+    });
+    depthBuffer->SetResource(g_SceneDepthBuffer.GetResource());
+
+    auto normalBuffer = g_renderGraphStoraged->CreateResource(L"NormalBuffer", {
+        RenderGraph::RenderGraphResourceType::RTV,
+        g_SceneNormalBuffer.GetFormat(),
+        g_SceneNormalBuffer.GetWidth(),
+        g_SceneNormalBuffer.GetHeight()
+    });
+    normalBuffer->SetResource(g_SceneNormalBuffer.GetResource());
+
+    auto shadowBuffer = g_renderGraphStoraged->CreateResource(L"ShadowBuffer", {
+        RenderGraph::RenderGraphResourceType::DSV,
+        g_ShadowBuffer.GetFormat(),
+        g_ShadowBuffer.GetWidth(),
+        g_ShadowBuffer.GetHeight()
+    });
+    shadowBuffer->SetResource(g_ShadowBuffer.GetResource());
+
+    auto velocityBuffer = g_renderGraphStoraged->CreateResource(L"VelocityBuffer", {
+        RenderGraph::RenderGraphResourceType::RTV,
+        g_VelocityBuffer.GetFormat(),
+        g_VelocityBuffer.GetWidth(),
+        g_VelocityBuffer.GetHeight()
+    });
+    velocityBuffer->SetResource(g_VelocityBuffer.GetResource());
+    // Create storaged nodes to use/reuse later on
+    auto shadowPassNode         = std::make_unique<RenderGraph::LambdaContextRenderPass>(L"ShadowPass", &Sponza::ShadowPass);
+    auto depthPrePassNode       = std::make_unique<RenderGraph::LambdaContextRenderPass>(L"DepthPrePass", &Sponza::DepthPrePass);
+    auto mainRenderPassNode     = std::make_unique<RenderGraph::LambdaContextRenderPass>(L"MainRenderPass", &Sponza::MainRenderPass);
+    auto ssaoPassNode           = std::make_unique<RenderGraph::LambdaContextRenderPass>(L"SSAOPass", &Sponza::SSAOPass);
+    auto lightGridPassNode      = std::make_unique<RenderGraph::LambdaContextRenderPass>(L"LightGridPass", &Sponza::LightGridPass);
+    auto lightShadowPassNode    = std::make_unique<RenderGraph::LambdaContextRenderPass>(L"LightShadowPass", &Sponza::LightShadowPass);
+    auto taaResolvePassNode     = std::make_unique<RenderGraph::LambdaContextRenderPass>(L"TAAResolvePass", &Sponza::ResolveTAA);
+    auto velocityPassNode       = std::make_unique<RenderGraph::LambdaContextRenderPass>(L"VelocityGatherPass", &Sponza::GenerateCameraVelocityBuffer);
+    auto motionBlurPassNode     = std::make_unique<RenderGraph::LambdaContextRenderPass>(L"MotionBlurPass", &Sponza::RenderBlur);
+    auto depthOfFieldPassNode   = std::make_unique<RenderGraph::LambdaContextRenderPass>(L"DepthOfFieldPass", &Sponza::RenderDOF);
+    auto particleRenderPassNode = std::make_unique<RenderGraph::LambdaContextRenderPass>(L"ParticleRenderPass", &Sponza::RenderParticles);
+    auto particleUpdatePassNode = std::make_unique<RenderGraph::LambdaContextRenderPass>(L"ParticleUpdatePass", &Sponza::RecalculateParticles);
+    g_renderGraphStoraged->StoreNode(std::move(particleUpdatePassNode), L"ParticleUpdatePass");
+    g_renderGraphStoraged->StoreNode(std::move(particleRenderPassNode), L"ParticleRenderPass");
+    g_renderGraphStoraged->StoreNode(std::move(depthOfFieldPassNode), L"DepthOfFieldPass");
+    g_renderGraphStoraged->StoreNode(std::move(motionBlurPassNode), L"MotionBlurPass");
+    g_renderGraphStoraged->StoreNode(std::move(velocityPassNode), L"VelocityGatherPass");
+    g_renderGraphStoraged->StoreNode(std::move(taaResolvePassNode), L"TAAResolvePass");
+    g_renderGraphStoraged->StoreNode(std::move(lightShadowPassNode), L"LightShadowPass");
+    g_renderGraphStoraged->StoreNode(std::move(lightGridPassNode), L"LightGridPass");
+    g_renderGraphStoraged->StoreNode(std::move(ssaoPassNode), L"SSAOPass");
+    g_renderGraphStoraged->StoreNode(std::move(shadowPassNode), L"ShadowPass");
+    g_renderGraphStoraged->StoreNode(std::move(depthPrePassNode), L"DepthPrePass");
+    g_renderGraphStoraged->StoreNode(std::move(mainRenderPassNode), L"MainRenderPass");
+    // Create edge transition data
+    auto shadowPixelData = std::make_unique<RenderGraph::RenderGraphEdgeResourceData>(
+        RenderGraph::RenderGraphEdgeResourceData{
+            shadowBuffer, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE
+        });
+    auto velocityNonPixelData = std::make_unique<RenderGraph::RenderGraphEdgeResourceData>(
+        RenderGraph::RenderGraphEdgeResourceData{
+            velocityBuffer,
+            D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE
+        });
+    auto velocityUnorderedData = std::make_unique<RenderGraph::RenderGraphEdgeResourceData>(
+        RenderGraph::RenderGraphEdgeResourceData{
+            velocityBuffer,
+            D3D12_RESOURCE_STATE_UNORDERED_ACCESS
+        });
+    auto velocityPixelData = std::make_unique<RenderGraph::RenderGraphEdgeResourceData>(
+        RenderGraph::RenderGraphEdgeResourceData{
+            velocityBuffer, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE
+        });
+    auto depthNonPixelData = std::make_unique<RenderGraph::RenderGraphEdgeResourceData>(
+        RenderGraph::RenderGraphEdgeResourceData{
+            depthBuffer,
+            D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE
+        });
+    auto colorNonPixelData = std::make_unique<RenderGraph::RenderGraphEdgeResourceData>(
+        RenderGraph::RenderGraphEdgeResourceData{
+            backBuffer,
+            D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE
+        });
+    auto colorUnorderedData = std::make_unique<RenderGraph::RenderGraphEdgeResourceData>(
+        RenderGraph::RenderGraphEdgeResourceData{
+            backBuffer,
+            D3D12_RESOURCE_STATE_UNORDERED_ACCESS
+        });
+    auto colorRenderTargetData = std::make_unique<RenderGraph::RenderGraphEdgeResourceData>(
+        RenderGraph::RenderGraphEdgeResourceData{
+            backBuffer,
+            D3D12_RESOURCE_STATE_RENDER_TARGET
+        });
+    auto depthReadData = std::make_unique<RenderGraph::RenderGraphEdgeResourceData>(
+        RenderGraph::RenderGraphEdgeResourceData{
+            depthBuffer,
+            D3D12_RESOURCE_STATE_DEPTH_READ
+        });
+    auto dummyData = std::make_unique<RenderGraph::RenderGraphEdgeResourceData>(
+        RenderGraph::RenderGraphEdgeResourceData{
+            nullptr,
+            D3D12_RESOURCE_STATE_COMMON
+        });
+    g_renderGraphStoraged->StoreEdge(std::move(shadowPixelData), L"ShadowPixel");
+    g_renderGraphStoraged->StoreEdge(std::move(depthNonPixelData), L"DepthNonPixel");
+    g_renderGraphStoraged->StoreEdge(std::move(velocityNonPixelData), L"VelocityNonPixel");
+    g_renderGraphStoraged->StoreEdge(std::move(velocityUnorderedData), L"VelocityUnordered");
+    g_renderGraphStoraged->StoreEdge(std::move(velocityPixelData), L"VelocityPixel");
+    g_renderGraphStoraged->StoreEdge(std::move(colorNonPixelData), L"ColorNonPixel");
+    g_renderGraphStoraged->StoreEdge(std::move(colorUnorderedData), L"ColorUnordered");
+    g_renderGraphStoraged->StoreEdge(std::move(colorNonPixelData), L"ColorRenderTarget");
+    g_renderGraphStoraged->StoreEdge(std::move(depthReadData), L"DepthRead");
+    g_renderGraphStoraged->StoreEdge(std::move(dummyData), L"Dummy");
+}
+
+void Sponza::ShadowPass(CommandContext& ctx)
+{
+    GraphicsContext& gfxContext = ctx.GetGraphicsContext();
+    ScopedTimer _prof(L"Render Shadow Map", gfxContext);
+    SetupGraphicsState(gfxContext);
+
+    m_SunShadow.UpdateMatrix(
+        -m_SunDirection,
+        Vector3(0.0f, -500.0f, 0.0f),
+        Vector3(ShadowDimX, ShadowDimY, ShadowDimZ),
+        static_cast<std::uint32_t>(g_ShadowBuffer.GetWidth()),
+        static_cast<std::uint32_t>(g_ShadowBuffer.GetHeight()),
+        16);
+
+    g_ShadowBuffer.BeginRendering(gfxContext);
+
+    // ----- Shadow PSO
+
+    gfxContext.SetPipelineState(m_ShadowPSO);
+    RenderObjects(
+        gfxContext,
+        m_SunShadow.GetViewProjMatrix(),
+        m_Camera.GetPosition(),
+        kOpaque);
+
+    // ----- Cutout Shadow PSO
+
+    gfxContext.SetPipelineState(m_CutoutShadowPSO);
+    RenderObjects(
+        gfxContext,
+        m_SunShadow.GetViewProjMatrix(),
+        m_Camera.GetPosition(),
+        kCutout
+    );
+
+    g_ShadowBuffer.EndRendering(gfxContext);
+}
+
+void Sponza::DepthPrePass(CommandContext& ctx)
+{
+    GraphicsContext& gfxContext = ctx.GetGraphicsContext();
+    ScopedTimer _prof(L"Z PrePass", gfxContext);
+
+    gfxContext.TransitionResource(g_SceneDepthBuffer, D3D12_RESOURCE_STATE_DEPTH_WRITE, true);
+    gfxContext.ClearDepth(g_SceneDepthBuffer);
+    gfxContext.SetPipelineState(m_DepthPSO);
+    gfxContext.SetDepthStencilTarget(g_SceneDepthBuffer.GetDSV());
+    gfxContext.SetViewportAndScissor(m_Viewport, m_Scissor);
+    RenderObjects(gfxContext, m_Camera.GetViewProjMatrix(), m_Camera.GetPosition(), kOpaque);
+
+    gfxContext.SetPipelineState(m_CutoutDepthPSO);
+    RenderObjects(gfxContext, m_Camera.GetViewProjMatrix(), m_Camera.GetPosition(), kCutout);
+}
+
+void Sponza::MainRenderPass(CommandContext& ctx)
+{
+    GraphicsContext& gfxContext = ctx.GetGraphicsContext();
+    ScopedTimer _prof(L"Main Render", gfxContext);
+
+    gfxContext.TransitionResource(g_SceneColorBuffer, D3D12_RESOURCE_STATE_RENDER_TARGET, true);
+    gfxContext.TransitionResource(g_SceneNormalBuffer, D3D12_RESOURCE_STATE_RENDER_TARGET, true);
+    gfxContext.ClearColor(g_SceneColorBuffer);
+
+    gfxContext.TransitionResource(g_SSAOFullScreen, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
+    gfxContext.SetDescriptorTable(Renderer::kCommonSRVs, Renderer::m_CommonTextures);
+
+    // Set up PS constants
+    struct {
+        Vector3 sunDirection;
+        Vector3 sunLight;
+        Vector3 ambientLight;
+        float ShadowTexelSize[4];
+        float InvTileDim[4];
+        uint32_t TileCount[4];
+        uint32_t FirstLightIndex[4];
+        uint32_t FrameIndexMod2;
+    } psConstants;
+
+    psConstants.sunDirection        = m_SunDirection;
+    psConstants.sunLight            = Vector3(1.0f, 1.0f, 1.0f) * m_SunLightIntensity;
+    psConstants.ambientLight        = Vector3(1.0f, 1.0f, 1.0f) * m_AmbientIntensity;
+    psConstants.ShadowTexelSize[0]  = 1.0f / g_ShadowBuffer.GetWidth();
+    psConstants.InvTileDim[0]       = 1.0f / Lighting::LightGridDim;
+    psConstants.InvTileDim[1]       = 1.0f / Lighting::LightGridDim;
+    psConstants.TileCount[0]        = Math::DivideByMultiple(g_SceneColorBuffer.GetWidth(), Lighting::LightGridDim);
+    psConstants.TileCount[1]        = Math::DivideByMultiple(g_SceneColorBuffer.GetHeight(), Lighting::LightGridDim);
+    psConstants.FirstLightIndex[0]  = Lighting::m_FirstConeLight;
+    psConstants.FirstLightIndex[1]  = Lighting::m_FirstConeShadowedLight;
+    psConstants.FrameIndexMod2      = m_FrameIndex;
+
+    gfxContext.SetDynamicConstantBufferView(Renderer::kMaterialConstants, sizeof(psConstants), &psConstants);
+
+    gfxContext.SetPipelineState(m_ModelPSO);
+    gfxContext.TransitionResource(g_SceneDepthBuffer, D3D12_RESOURCE_STATE_DEPTH_READ);
+    D3D12_CPU_DESCRIPTOR_HANDLE rtvs[]{ g_SceneColorBuffer.GetRTV(), g_SceneNormalBuffer.GetRTV() };
+    gfxContext.SetRenderTargets(ARRAYSIZE(rtvs), rtvs, g_SceneDepthBuffer.GetDSV_DepthReadOnly());
+    gfxContext.SetViewportAndScissor(m_Viewport, m_Scissor);
+
+    RenderObjects(gfxContext, m_Camera.GetViewProjMatrix(), m_Camera.GetPosition(), Sponza::kOpaque);
+    gfxContext.SetPipelineState(m_CutoutModelPSO);
+    RenderObjects(gfxContext, m_Camera.GetViewProjMatrix(), m_Camera.GetPosition(), Sponza::kCutout);
+}
+
+void Sponza::SSAOPass(CommandContext& ctx) {
+    GraphicsContext& gfxContext = ctx.GetGraphicsContext();
+    SSAO::Render(gfxContext, m_Camera);
+};
+
+void Sponza::LightGridPass(CommandContext& ctx) {
+    GraphicsContext& gfxContext = ctx.GetGraphicsContext();
+    Lighting::FillLightGrid(gfxContext, m_Camera);
+};
+
+void Sponza::LightShadowPass(CommandContext& ctx) {
+    GraphicsContext& gfxContext = ctx.GetGraphicsContext();
+    SetupGraphicsState(gfxContext);
+    RenderLightShadows(gfxContext, m_Camera);
+}
+
+void Sponza::SetupGraphicsState(GraphicsContext& gfxContext) {
+    gfxContext.SetRootSignature(Renderer::m_RootSig);
+    gfxContext.SetDescriptorHeap(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV, Renderer::s_TextureHeap.GetHeapPointer());
+    gfxContext.SetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+    gfxContext.SetIndexBuffer(m_Model.GetIndexBuffer());
+    gfxContext.SetVertexBuffer(0, m_Model.GetVertexBuffer());
+}
+
+void Sponza::RecalculateParticles(CommandContext& ctx) {
+    ParticleEffectManager::Update(ctx.GetComputeContext(), Graphics::GetFrameTime());
+}
+
+void Sponza::GenerateCameraVelocityBuffer(CommandContext& ctx) {
+    // Some systems generate a per-pixel velocity buffer to better track dynamic and skinned meshes.  Everything
+    // is static in our scene, so we generate velocity from camera motion and the depth buffer.  A velocity buffer
+    // is necessary for all temporal effects (and motion blur).
+    MotionBlur::GenerateCameraVelocityBuffer(ctx.GetGraphicsContext(), m_Camera, true);
+}
+
+void Sponza::ResolveTAA(CommandContext& ctx) {
+    TemporalEffects::ResolveImage(ctx.GetGraphicsContext());
+}
+
+void Sponza::RenderParticles(CommandContext& ctx) {
+    ParticleEffectManager::Render(ctx.GetGraphicsContext(), m_Camera, g_SceneColorBuffer, g_SceneDepthBuffer,  g_LinearDepth[m_FrameIndex]);
+}
+
+void Sponza::RenderDOF(CommandContext& ctx) {
+    DepthOfField::Render(ctx.GetGraphicsContext(), m_Camera.GetNearClip(), m_Camera.GetFarClip());
+}
+
+void Sponza::RenderBlur(CommandContext& ctx) {
+    MotionBlur::RenderObjectBlur(ctx.GetGraphicsContext(), g_VelocityBuffer);
 }

--- a/MiniEngine/Model/SponzaRenderer.h
+++ b/MiniEngine/Model/SponzaRenderer.h
@@ -33,6 +33,21 @@ namespace Sponza
     void RenderGraphStartup();
     void Cleanup( void );
 
+    void DepthPrePass( CommandContext& ctx );
+    void ShadowPass( CommandContext& ctx );
+    void MainRenderPass( CommandContext& ctx );
+    void LightGridPass( CommandContext& ctx );
+    void SSAOPass( CommandContext& ctx );
+    void LightShadowPass( CommandContext& ctx );
+    void RecalculateParticles( CommandContext& ctx );
+    void GenerateCameraVelocityBuffer( CommandContext& ctx );
+    void ResolveTAA( CommandContext& ctx );
+    void RenderParticles( CommandContext& ctx );
+    void RenderDOF( CommandContext& ctx );
+    void RenderBlur( CommandContext& ctx );
+    
+    void SetupGraphicsState(GraphicsContext& gfxContext);
+
     void RenderScene(
         GraphicsContext& gfxContext,
         const Math::Camera& camera,
@@ -49,11 +64,24 @@ namespace Sponza
         bool skipDiffusePass = false,
         bool skipShadowMap = false);
 
+    void RenderSceneRenderGraphStoraged(
+        GraphicsContext& gfxContext,
+        const Math::Camera& camera,
+        const D3D12_VIEWPORT& viewport,
+        const D3D12_RECT& scissor,
+        bool skipDiffusePass = false,
+        bool skipShadowMap = false);
+
     const ModelH3D& GetModel();
 
     //extern std::unique_ptr<RenderGraph::RenderGraph> g_renderGraph;
     extern RenderGraph::RenderGraph* g_renderGraph;
+    extern RenderGraph::RenderGraphStoraged* g_renderGraphStoraged;
     extern Math::Vector3 m_SunDirection;
+    extern Math::Camera m_Camera;
+    extern D3D12_VIEWPORT m_Viewport;
+    extern D3D12_RECT m_Scissor;
+    extern std::uint32_t m_FrameIndex;
     extern ShadowCamera m_SunShadow;
     extern ExpVar m_AmbientIntensity;
     extern ExpVar m_SunLightIntensity;

--- a/MiniEngine/ModelViewer/ModelViewer.cpp
+++ b/MiniEngine/ModelViewer/ModelViewer.cpp
@@ -258,17 +258,33 @@ void ModelViewer::RenderScene( void )
     const D3D12_VIEWPORT& viewport = m_MainViewport;
     const D3D12_RECT& scissor = m_MainScissor;
 
-    ParticleEffectManager::Update(gfxContext.GetComputeContext(), Graphics::GetFrameTime());
-
     if (m_ModelInst.IsNull() && !m_useRenderGraph)
     {
 #ifdef LEGACY_RENDERER
+        ParticleEffectManager::Update(gfxContext.GetComputeContext(), Graphics::GetFrameTime());
+
         Sponza::RenderScene(gfxContext, m_Camera, viewport, scissor);
+
+        // Some systems generate a per-pixel velocity buffer to better track dynamic and skinned meshes.  Everything
+        // is static in our scene, so we generate velocity from camera motion and the depth buffer.  A velocity buffer
+        // is necessary for all temporal effects (and motion blur).
+        MotionBlur::GenerateCameraVelocityBuffer(gfxContext, m_Camera, true);
+
+        TemporalEffects::ResolveImage(gfxContext);
+
+        ParticleEffectManager::Render(gfxContext, m_Camera, g_SceneColorBuffer, g_SceneDepthBuffer,  g_LinearDepth[FrameIndex]);
+
+        // Until I work out how to couple these two, it's "either-or".
+        if (DepthOfField::Enable)
+            DepthOfField::Render(gfxContext, m_Camera.GetNearClip(), m_Camera.GetFarClip());
+        else
+            MotionBlur::RenderObjectBlur(gfxContext, g_VelocityBuffer);
 #endif
     }
     else if (m_ModelInst.IsNull() && m_useRenderGraph)
     {
-        Sponza::RenderSceneRenderGraph(gfxContext, m_Camera, viewport, scissor);
+        //Sponza::RenderSceneRenderGraph(gfxContext, m_Camera, viewport, scissor);
+        Sponza::RenderSceneRenderGraphStoraged(gfxContext, m_Camera, viewport, scissor);
     }
     else
     {
@@ -349,21 +365,6 @@ void ModelViewer::RenderScene( void )
             sorter.RenderMeshes(MeshSorter::kTransparent, gfxContext, globals);
         }
     }
-
-    // Some systems generate a per-pixel velocity buffer to better track dynamic and skinned meshes.  Everything
-    // is static in our scene, so we generate velocity from camera motion and the depth buffer.  A velocity buffer
-    // is necessary for all temporal effects (and motion blur).
-    MotionBlur::GenerateCameraVelocityBuffer(gfxContext, m_Camera, true);
-
-    TemporalEffects::ResolveImage(gfxContext);
-
-    ParticleEffectManager::Render(gfxContext, m_Camera, g_SceneColorBuffer, g_SceneDepthBuffer,  g_LinearDepth[FrameIndex]);
-
-    // Until I work out how to couple these two, it's "either-or".
-    if (DepthOfField::Enable)
-        DepthOfField::Render(gfxContext, m_Camera.GetNearClip(), m_Camera.GetFarClip());
-    else
-        MotionBlur::RenderObjectBlur(gfxContext, g_VelocityBuffer);
 
     gfxContext.Finish();
 }


### PR DESCRIPTION
An alternative Render Graph implementation with RenderPass and Resource reuse for better deserialization (not yet included). Also modified to roughly cover the whole render pipeline (but that's WIP).
Also alters LambdaRenderPass' interface for lambda to accept `CommandContext` object instead of `ID3D12CommandList` pointer that was mostly unused while `CommandContext` was passed via capture group and extensively used while containing the CommandList.